### PR TITLE
Add Sentry publish GHA

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,11 @@
+---
+minVersion: 0.34.1
+github:
+  owner: getsentry
+  repo: sentry-forked-jsonnet
+changelogPolicy: auto
+releaseBranchPrefix: release
+targets:
+  - name: pypi
+  - name: sentry-pypi
+    internalPypiRepo: getsentry/pypi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13] 
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13'] 
         os: [ubuntu-latest, macos-latest] 
         arch: [x86_64, arm64] 
     timeout-minutes: 10
@@ -22,6 +22,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
+            # Skip PyPy, 32-bit Windows, 32-bit Linux, and CPython before 3.9.
+            # See https://cibuildwheel.readthedocs.io/en/stable/options/#examples_1
+            CIBW_SKIP: "*-win32 pp* *-manylinux_i686 *-musllinux_i686 cp36-* cp37-* cp38-*"
             CIBW_TEST_COMMAND: >
                 python {package}/python/_jsonnet_test.py
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,5 +30,5 @@ jobs:
                 python {package}/python/_jsonnet_test.py
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,19 +9,24 @@ on:
 jobs:
   dist:
     name: Create wheel and source distribution for sentry_forked_jsonnet
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13] 
+        os: [ubuntu-latest, macos-latest] 
+        arch: [x86_64, arm64] 
     timeout-minutes: 10
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
-      - name: "Prepare artifacts"
-        run: |
-          pip install wheel
-          pip install build
-          python -m build --wheel
-      - uses: actions/upload-artifact@v3.1.1
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+            CIBW_TEST_COMMAND: >
+                python {package}/python/_jsonnet_test.py
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
-          path: dist/*
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,3 @@
-# TODO: This one and sentry_jsonish are almost the same.
-# A reusable flow would help.
 name: build sentry_forked_jsonnet
 
 on:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,9 @@ name: build sentry_forked_jsonnet
 
 on:
   push:
-  workflow_dispatch:
+    branches:
+      - master
+      - release/**
 
 jobs:
   dist:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,9 @@ name: build sentry_forked_jsonnet
 on:
   push:
     branches:
-      - main
+      - master
       - release/**
+  workflow_dispatch:
 
 jobs:
   dist:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,6 @@ name: build sentry_forked_jsonnet
 
 on:
   push:
-    branches:
-      - master
-      - release/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,29 @@
+# TODO: This one and sentry_jsonish are almost the same.
+# A reusable flow would help.
+name: build sentry_forked_jsonnet
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+
+jobs:
+  dist:
+    name: Create wheel and source distribution for sentry_forked_jsonnet
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+      - name: "Prepare artifacts"
+        run: |
+          pip install wheel
+          pip install build
+          python -m build --wheel
+      - uses: actions/upload-artifact@v3.1.1
+        with:
+          name: ${{ github.sha }}
+          path: dist/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,5 +30,5 @@ jobs:
                 python {package}/python/_jsonnet_test.py
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13'] 
         os: [ubuntu-latest, macos-latest] 
         arch: [x86_64, arm64] 
     timeout-minutes: 10
@@ -20,11 +19,11 @@ jobs:
         with:
           python-version: 3.13
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.21.3
         env:
-            # Skip PyPy, 32-bit Windows, 32-bit Linux, and CPython before 3.9.
+            # Skip PyPy, 32-bit Windows, 32-bit Linux, and CPython before 3.10.
             # See https://cibuildwheel.readthedocs.io/en/stable/options/#examples_1
-            CIBW_SKIP: "*-win32 pp* *-manylinux_i686 *-musllinux_i686 cp36-* cp37-* cp38-*"
+            CIBW_SKIP: "*-win32 pp* *-manylinux_i686 *-musllinux_i686 cp36-* cp37-* cp38-* cp39-*"
             CIBW_TEST_COMMAND: >
                 python {package}/python/_jsonnet_test.py
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: Package CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: "Run CI"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Run tests
+        run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ jsonnet_ext = Extension(
     language='c++'
 )
 
-setup(name='jsonnet',
+setup(name='sentry-forked-jsonnet',
       url='https://jsonnet.org',
       project_urls={
         'Source': 'https://github.com/google/jsonnet',


### PR DESCRIPTION
This PR adds configs and GHA for publishing via craft to pypi and internal Sentry pypi

Test runs: https://github.com/getsentry/sentry-forked-jsonnet/actions/runs/11508880667/job/32037952000?pr=5