### PR TITLE
Add changelog

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,6 @@ name: build sentry_forked_jsonnet
 on:
   push:
     branches:
-      - master
       - release/**
 
 jobs:


### PR DESCRIPTION
This PR adds the CHANGLOG.md file for craft & removes the build trigger on master (should only trigger on release branches)