### PR TITLE
Fix regex in bump-script.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -13,4 +13,4 @@ function replace() {
     grep "$2" $3  # verify that replacement was successful
 }
 
-replace "version=\"[0-9.]+\""  "version=\"$NEW_VERSION\"" setup.py
+replace "version=\"[0-9.-]+\""  "version=\"$NEW_VERSION\"" setup.py


### PR DESCRIPTION
Since apparently X.X.X.X version names aren't allowed, we have to add support in the bump-script for X.X.X-X names.